### PR TITLE
Grab frame for mjpeg streams

### DIFF
--- a/src/labthings_fastapi/outputs/mjpeg_stream.py
+++ b/src/labthings_fastapi/outputs/mjpeg_stream.py
@@ -130,6 +130,15 @@ class MJPEGStream:
         i = await self.next_frame()
         async with self.buffer_for_reading(i) as frame:
             return copy(frame)
+    
+    async def next_frame_size(self) -> int:
+        """Wait for the next frame and return its size
+        
+        This is useful if you want to use JPEG size as a sharpness metric.
+        """
+        i = await self.next_frame()
+        async with self.buffer_for_reading(i) as frame:
+            return len(frame)
 
     async def frame_async_generator(self) -> AsyncGenerator[bytes, None]:
         """A generator that yields frames as bytes"""

--- a/src/labthings_fastapi/outputs/mjpeg_stream.py
+++ b/src/labthings_fastapi/outputs/mjpeg_stream.py
@@ -13,6 +13,7 @@ from typing import (
     overload,
 )
 from typing_extensions import Self
+from copy import copy
 from contextlib import asynccontextmanager
 import threading
 import anyio
@@ -119,6 +120,16 @@ class MJPEGStream:
         async with self.condition:
             await self.condition.wait()
             return self.last_frame_i
+        
+    async def grab_frame(self) -> bytes:
+        """Wait for the next frame, and return it
+        
+        This copies the frame for safety, so we can release the
+        read lock on the buffer.
+        """
+        i = await self.next_frame()
+        async with self.buffer_for_reading(i) as frame:
+            return copy(frame)
 
     async def frame_async_generator(self) -> AsyncGenerator[bytes, None]:
         """A generator that yields frames as bytes"""

--- a/src/labthings_fastapi/outputs/mjpeg_stream.py
+++ b/src/labthings_fastapi/outputs/mjpeg_stream.py
@@ -120,20 +120,20 @@ class MJPEGStream:
         async with self.condition:
             await self.condition.wait()
             return self.last_frame_i
-        
+
     async def grab_frame(self) -> bytes:
         """Wait for the next frame, and return it
-        
+
         This copies the frame for safety, so we can release the
         read lock on the buffer.
         """
         i = await self.next_frame()
         async with self.buffer_for_reading(i) as frame:
             return copy(frame)
-    
+
     async def next_frame_size(self) -> int:
         """Wait for the next frame and return its size
-        
+
         This is useful if you want to use JPEG size as a sharpness metric.
         """
         i = await self.next_frame()


### PR DESCRIPTION
Add methods to grab a single frame, or just the size of the next frame, from an MJPEG stream. These make it easy to add `grab_frame` and `grab_frame_size` to the camera object. It might be nice if they appeared automatically as properties, somehow "on" the MJPEG stream. However, Thing Description doesn't understand nested Things, so it would mess with the simplicity of our current API.

We could of course expose the endpoints without listing them in the TD, but that that point we'd have to add the actions anyway, so why worry.