### PR TITLE
Write properties using PUT

### DIFF
--- a/src/labthings_fastapi/client/__init__.py
+++ b/src/labthings_fastapi/client/__init__.py
@@ -68,7 +68,7 @@ class ThingClient:
         return r.json()
 
     def set_property(self, path: str, value: Any):
-        r = self.client.post(urljoin(self.path, path), json=value)
+        r = self.client.put(urljoin(self.path, path), json=value)
         r.raise_for_status()
 
     def invoke_action(self, path: str, **kwargs):

--- a/src/labthings_fastapi/descriptors/property.py
+++ b/src/labthings_fastapi/descriptors/property.py
@@ -144,7 +144,7 @@ class PropertyDescriptor:
                 return self.__set__(thing, body)
 
             set_property.__annotations__["body"] = Annotated[self.model, Body()]
-            app.post(
+            app.put(
                 thing.path + self.name,
                 status_code=201,
                 response_description="Property set successfully",

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -99,7 +99,7 @@ def test_sync_action():
         client.put("/thing/boolprop", json=False)
         r = client.get("/thing/boolprop")
         assert r.json() is False
-        r = client.put("/thing/toggle_boolprop", json={})
+        r = client.post("/thing/toggle_boolprop", json={})
         assert r.status_code in [200, 201]
         r = client.get("/thing/boolprop")
         assert r.json() is True
@@ -110,7 +110,7 @@ def test_setting_from_thread():
         client.put("/thing/boolprop", json=False)
         r = client.get("/thing/boolprop")
         assert r.json() is False
-        r = client.put("/thing/toggle_boolprop_from_thread", json={})
+        r = client.post("/thing/toggle_boolprop_from_thread", json={})
         assert r.status_code in [200, 201]
         r = client.get("/thing/boolprop")
         assert r.json() is True

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -60,7 +60,7 @@ def test_instantiation_with_model():
 def test_property_get_and_set():
     with TestClient(server.app) as client:
         test_str = "A silly test string"
-        client.post("/thing/stringprop", json=test_str)
+        client.put("/thing/stringprop", json=test_str)
         after_value = client.get("/thing/stringprop")
         assert after_value.json() == test_str
 
@@ -69,7 +69,7 @@ def test_propertydescriptor():
     with TestClient(server.app) as client:
         r = client.get("/thing/boolprop")
         assert r.json() is False
-        client.post("/thing/boolprop", json=True)
+        client.put("/thing/boolprop", json=True)
         r = client.get("/thing/boolprop")
         assert r.json() is True
 
@@ -78,7 +78,7 @@ def test_decorator_with_no_annotation():
     with TestClient(server.app) as client:
         r = client.get("/thing/undoc")
         assert r.json() is None
-        r = client.post("/thing/undoc", json="foo")
+        r = client.put("/thing/undoc", json="foo")
         assert r.status_code != 200
 
 
@@ -86,20 +86,20 @@ def test_readwrite_with_getter_and_setter():
     with TestClient(server.app) as client:
         r = client.get("/thing/floatprop")
         assert r.json() == 1.0
-        r = client.post("/thing/floatprop", json=2.0)
+        r = client.put("/thing/floatprop", json=2.0)
         assert r.status_code == 201
         r = client.get("/thing/floatprop")
         assert r.json() == 2.0
-        r = client.post("/thing/floatprop", json="foo")
+        r = client.put("/thing/floatprop", json="foo")
         assert r.status_code != 200
 
 
 def test_sync_action():
     with TestClient(server.app) as client:
-        client.post("/thing/boolprop", json=False)
+        client.put("/thing/boolprop", json=False)
         r = client.get("/thing/boolprop")
         assert r.json() is False
-        r = client.post("/thing/toggle_boolprop", json={})
+        r = client.put("/thing/toggle_boolprop", json={})
         assert r.status_code in [200, 201]
         r = client.get("/thing/boolprop")
         assert r.json() is True
@@ -107,10 +107,10 @@ def test_sync_action():
 
 def test_setting_from_thread():
     with TestClient(server.app) as client:
-        client.post("/thing/boolprop", json=False)
+        client.put("/thing/boolprop", json=False)
         r = client.get("/thing/boolprop")
         assert r.json() is False
-        r = client.post("/thing/toggle_boolprop_from_thread", json={})
+        r = client.put("/thing/toggle_boolprop_from_thread", json={})
         assert r.status_code in [200, 201]
         r = client.get("/thing/boolprop")
         assert r.json() is True

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -14,7 +14,7 @@ def test_websocket_observeproperty():
                 {"messageType": "addPropertyObservation", "data": {"foo": True}}
             )
             test_str = "Abcdef"
-            client.post("/my_thing/foo", json=test_str)
+            client.put("/my_thing/foo", json=test_str)
             message = ws.receive_json(mode="text")
             assert message["data"]["foo"] == test_str
             ws.close(1000)


### PR DESCRIPTION
I have been writing properties using POST - but both the WoT spec and LabThings 1 use PUT. This is a trivial change, but important to comply with the standard.