### PR TITLE
Safer metadata dependency

### DIFF
--- a/src/labthings_fastapi/client/in_server.py
+++ b/src/labthings_fastapi/client/in_server.py
@@ -70,7 +70,7 @@ def property_descriptor(
         return getattr(obj._wrapped_thing, self.name)
 
     def __set__(self, obj: DirectThingClient, value: Any):
-        setattr(obj, self.name, value)
+        setattr(obj._wrapped_thing, self.name, value)
 
     if readable:
         __get__.__annotations__["return"] = model

--- a/src/labthings_fastapi/dependencies/metadata.py
+++ b/src/labthings_fastapi/dependencies/metadata.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable
 from collections.abc import Mapping
 
 from fastapi import Depends, Request
@@ -13,10 +13,37 @@ def get_thing_states(request: Request) -> dict:
     This is intended to make it easy for a Thing to summarise the other Things
     it's associated with, for example it's used to populate the UserComment
     EXIF field in the OpenFlexure Microscope.
+
+    This function evaluates metadata and provides the dependent function with
+    a dictionary. For a version that provides a callable to execute later,
+    see `thing_states_getter`.
     """
-    server = find_thing_server(request.app)
-    metadata = {k: v.thing_state for k, v in server.things.items()}
-    return metadata
+    get_metadata = thing_states_getter(request)
+    return get_metadata()
 
 
 ThingStates = Annotated[Mapping[str, Any], Depends(get_thing_states)]
+
+
+def thing_states_getter(request: Request) -> Callable[..., Mapping[str, Any]]:
+    """A dependency to retrieve summary metadata from all Things in this server.
+    
+    This is intended to make it easy for a Thing to summarise the other Things
+    it's associated with, for example it's used to populate the UserComment
+    EXIF field in the OpenFlexure Microscope.
+
+    `thing_states_getter` differs from `get_thing_states` because the latter
+    is evaluated once, before the action, and this dependency returns a function
+    that collects the metadata when it's run.
+
+    If your action is likely to be run from other actions where the metadata
+    changes, you should use this version.
+    """
+    server = find_thing_server(request.app)
+    def get_metadata():
+        """Retrieve metadata from each Thing"""
+        return {k: v.thing_state for k, v in server.things.items()}
+    return get_metadata
+
+
+GetThingStates = Annotated[Callable[..., Mapping[str, Any]], Depends(thing_states_getter)]

--- a/src/labthings_fastapi/dependencies/raw_thing.py
+++ b/src/labthings_fastapi/dependencies/raw_thing.py
@@ -11,7 +11,7 @@ ThingInstance = TypeVar("ThingInstance", bound=Thing)
 
 
 def find_raw_thing_by_class(
-    cls: type[ThingInstance]
+    cls: type[ThingInstance],
 ) -> Callable[[Request], ThingInstance]:
     """Generate a dependency that locates the instance of a specific Thing subclass
 

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -10,6 +10,7 @@ from labthings_fastapi.decorators import thing_action, thing_property
 from labthings_fastapi.dependencies.thing import direct_thing_client_dependency
 from labthings_fastapi.dependencies.metadata import GetThingStates
 
+
 class ThingOne(Thing):
     def __init__(self):
         Thing.__init__(self)
@@ -18,37 +19,36 @@ class ThingOne(Thing):
     @thing_property
     def a(self):
         return self._a
+
     @a.setter
     def a(self, value):
         self._a = value
-    
+
     @property
     def thing_state(self):
         return {"a": self.a}
-    
+
 
 ThingOneDep = direct_thing_client_dependency(ThingOne, "/thing_one/")
-    
+
 
 class ThingTwo(Thing):
-    A_VALUES = [1,2,3]
+    A_VALUES = [1, 2, 3]
 
     @property
     def thing_state(self):
         return {"a": 1}
-    
+
     @thing_action
     def count_and_watch(
-        self,
-        thing_one: ThingOneDep,
-        get_metadata: GetThingStates
+        self, thing_one: ThingOneDep, get_metadata: GetThingStates
     ) -> Mapping[str, Mapping[str, Any]]:
         metadata = {}
         for a in self.A_VALUES:
             thing_one.a = a
             metadata[f"a_{a}"] = get_metadata()
         return metadata
-        
+
 
 def test_fresh_metadata():
     server = ThingServer()

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -1,0 +1,64 @@
+"""
+This tests metadata retrieval, as used by e.g. the camera for EXIF info
+"""
+from typing import Any, Mapping
+from fastapi.testclient import TestClient
+from labthings_fastapi.thing_server import ThingServer
+from temp_client import poll_task
+from labthings_fastapi.thing import Thing
+from labthings_fastapi.decorators import thing_action, thing_property
+from labthings_fastapi.dependencies.thing import direct_thing_client_dependency
+from labthings_fastapi.dependencies.metadata import GetThingStates
+
+class ThingOne(Thing):
+    def __init__(self):
+        Thing.__init__(self)
+        self._a = 0
+
+    @thing_property
+    def a(self):
+        return self._a
+    @a.setter
+    def a(self, value):
+        self._a = value
+    
+    @property
+    def thing_state(self):
+        return {"a": self.a}
+    
+
+ThingOneDep = direct_thing_client_dependency(ThingOne, "/thing_one/")
+    
+
+class ThingTwo(Thing):
+    A_VALUES = [1,2,3]
+
+    @property
+    def thing_state(self):
+        return {"a": 1}
+    
+    @thing_action
+    def count_and_watch(
+        self,
+        thing_one: ThingOneDep,
+        get_metadata: GetThingStates
+    ) -> Mapping[str, Mapping[str, Any]]:
+        metadata = {}
+        for a in self.A_VALUES:
+            thing_one.a = a
+            metadata[f"a_{a}"] = get_metadata()
+        return metadata
+        
+
+def test_fresh_metadata():
+    server = ThingServer()
+    server.add_thing(ThingOne(), "/thing_one/")
+    server.add_thing(ThingTwo(), "/thing_two/")
+    with TestClient(server.app) as client:
+        r = client.post("/thing_two/count_and_watch")
+        invocation = poll_task(client, r.json())
+        assert invocation["status"] == "completed"
+        out = invocation["output"]
+        for a in ThingTwo.A_VALUES:
+            assert out[f"a_{a}"]["/thing_one/"]["a"] == a
+            assert out[f"a_{a}"]["/thing_two/"]["a"] == 1


### PR DESCRIPTION
The `ThingStates` dependency was evaluated before actions were run. When taking multiple captures, for example, this meant that the stage position was not updated.

I have resolved this by replacing the dependency with `GetThingStates`, a callable that returns the same dictionary. This updates when it is called, and thus ensures metadata is always fresh. `labthings-picamera2` and `openflexure-microscope-server` have been updated accordingly.