### PR TITLE
Don't fail when constructing LogRecordModels from bad logs

### DIFF
--- a/src/labthings_fastapi/actions/invocation_model.py
+++ b/src/labthings_fastapi/actions/invocation_model.py
@@ -35,7 +35,17 @@ class LogRecordModel(BaseModel):
     def generate_message(cls, data: Any):
         if not hasattr(data, "message"):
             if isinstance(data, logging.LogRecord):
-                data.message = data.getMessage()
+                try:
+                    data.message = data.getMessage()
+                except (ValueError, TypeError) as e:
+                    # too many args causes an error - but errors
+                    # in validation can be a problem for us:
+                    # it will cause 500 errors when retrieving
+                    # the invocation.
+                    # This way, you can find and fix the source.
+                    data.message = (
+                        f"Error constructing message ({e}) " f"from {data!r}."
+                    )
         return data
 
 

--- a/tests/test_action_logging.py
+++ b/tests/test_action_logging.py
@@ -81,4 +81,4 @@ def test_logrecord_too_many_args():
         exc_info=None,
     )
     m = LogRecordModel.model_validate(record, from_attributes=True)
-    assert m.message.startsWith("Error")
+    assert m.message.startswith("Error")

--- a/tests/test_action_logging.py
+++ b/tests/test_action_logging.py
@@ -49,3 +49,36 @@ def test_logrecordmodel():
     )
     m = LogRecordModel.model_validate(record, from_attributes=True)
     assert m.levelname == record.levelname
+
+
+def test_logrecord_args():
+    record = logging.LogRecord(
+        name="recordName",
+        level=logging.INFO,
+        pathname="dummy/path",
+        lineno=0,
+        msg="mambo number %d",
+        args=(5,),
+        exc_info=None,
+    )
+    m = LogRecordModel.model_validate(record, from_attributes=True)
+    assert m.message == record.getMessage()
+
+
+def test_logrecord_too_many_args():
+    """Calling getMessage() will raise an error - but it should still validate
+
+    If it doesn't validate, it will cause every subsequent call to the action's
+    invocation record to return a 500 error.
+    """
+    record = logging.LogRecord(
+        name="recordName",
+        level=logging.INFO,
+        pathname="dummy/path",
+        lineno=0,
+        msg="mambo number %d",
+        args=(5, 6),
+        exc_info=None,
+    )
+    m = LogRecordModel.model_validate(record, from_attributes=True)
+    assert m.message.startsWith("Error")


### PR DESCRIPTION
LogRecord objects can have bad message format strings, and this was causing log serialisation to fail - with bad consequences (action objects became un-returnable).

I've now put exception handling in to allow even badly formatted LogRecord objects to be serialised, which should keep the server working and enable bad log statements to be fixed at source (as you know the file/line number).